### PR TITLE
Make evaluation context required in IFeatureFilter

### DIFF
--- a/src/filter/FeatureFilter.ts
+++ b/src/filter/FeatureFilter.ts
@@ -3,7 +3,7 @@
 
 export interface IFeatureFilter {
     name: string; // e.g. Microsoft.TimeWindow
-    evaluate(context?: IFeatureFilterEvaluationContext, appContext?: unknown): Promise<boolean> | boolean;
+    evaluate(context: IFeatureFilterEvaluationContext, appContext?: unknown): Promise<boolean> | boolean;
 }
 
 export interface IFeatureFilterEvaluationContext {


### PR DESCRIPTION
See https://github.com/microsoft/FeatureManagement-JavaScript/pull/5#discussion_r1561917719

`IFeatureFilterEvaluationContext` should be required for `evaluate()` impl of every filter, where `featureName` is provided.  This PR updates the interface. 

```ts
interface IFeatureFilterEvaluationContext {
    featureName: string;
    parameters?: unknown;
}
```