### PR TITLE
fix evaluation: FeatureFlag.enabled defaults to false

### DIFF
--- a/src/featureManager.ts
+++ b/src/featureManager.ts
@@ -36,8 +36,8 @@ export class FeatureManager {
             return false;
         }
 
-        if (featureFlag.enabled === false) {
-            // If the feature is explicitly disabled, then it is disabled.
+        if (featureFlag.enabled !== true) {
+            // If the feature is not explicitly enabled, then it is disabled by default.
             return false;
         }
 

--- a/src/featureManager.ts
+++ b/src/featureManager.ts
@@ -36,6 +36,9 @@ export class FeatureManager {
             return false;
         }
 
+        // Ensure that the feature flag is in the correct format. Feature providers should validate the feature flags, but we do it here as a safeguard.
+        validateFeatureFlagFormat(featureFlag);
+
         if (featureFlag.enabled !== true) {
             // If the feature is not explicitly enabled, then it is disabled by default.
             return false;
@@ -76,4 +79,10 @@ export class FeatureManager {
 
 interface FeatureManagerOptions {
     customFilters?: IFeatureFilter[];
+}
+
+function validateFeatureFlagFormat(featureFlag: any): void {
+    if (featureFlag.enabled !== undefined && typeof featureFlag.enabled !== "boolean") {
+        throw new Error(`Feature flag ${featureFlag.id} has an invalid 'enabled' value.`);
+    }
 }

--- a/test/noFilters.test.ts
+++ b/test/noFilters.test.ts
@@ -29,7 +29,7 @@ const featureFlagsDataObject = {
             },
             {
                 "id": "InvalidEnabled",
-                "description": "A feature flag with an invalid 'enabled' value, that returns false.",
+                "description": "A feature flag with an invalid 'enabled' value, that throws an exception.",
                 "enabled": "invalid",
                 "conditions": {
                     "client_filters": []
@@ -61,7 +61,7 @@ describe("feature flags with no filters", () => {
         return Promise.all([
             expect(featureManager.isEnabled("BooleanTrue")).eventually.eq(true),
             expect(featureManager.isEnabled("BooleanFalse")).eventually.eq(false),
-            expect(featureManager.isEnabled("InvalidEnabled")).eventually.eq(false),
+            expect(featureManager.isEnabled("InvalidEnabled")).eventually.rejectedWith("Feature flag InvalidEnabled has an invalid 'enabled' value."),
             expect(featureManager.isEnabled("Minimal")).eventually.eq(true),
             expect(featureManager.isEnabled("NoEnabled")).eventually.eq(false),
             expect(featureManager.isEnabled("EmptyConditions")).eventually.eq(true)

--- a/test/noFilters.test.ts
+++ b/test/noFilters.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+import { FeatureManager, ConfigurationObjectFeatureFlagProvider } from "./exportedApi";
+
+const featureFlagsDataObject = {
+    "feature_management": {
+        "feature_flags": [
+            {
+                "id": "BooleanTrue",
+                "description": "A feature flag with no Filters, that returns true.",
+                "enabled": true,
+                "conditions": {
+                    "client_filters": []
+                }
+            },
+            {
+                "id": "BooleanFalse",
+                "description": "A feature flag with no Filters, that returns false.",
+                "enabled": false,
+                "conditions": {
+                    "client_filters": []
+                }
+            },
+            {
+                "id": "InvalidEnabled",
+                "description": "A feature flag with an invalid 'enabled' value, that returns false.",
+                "enabled": "invalid",
+                "conditions": {
+                    "client_filters": []
+                }
+            },
+            {
+                "id": "Minimal",
+                "enabled": true
+            },
+            {
+                "id": "NoEnabled"
+            },
+            {
+                "id": "EmptyConditions",
+                "description": "A feature flag with no values in conditions, that returns true.",
+                "enabled": true,
+                "conditions": {
+                }
+            }
+        ]
+    }
+};
+
+describe("feature flags with no filters", () => {
+    it("should validate feature flags without filters", () => {
+        const provider = new ConfigurationObjectFeatureFlagProvider(featureFlagsDataObject);
+        const featureManager = new FeatureManager(provider);
+
+        return Promise.all([
+            expect(featureManager.isEnabled("BooleanTrue")).eventually.eq(true),
+            expect(featureManager.isEnabled("BooleanFalse")).eventually.eq(false),
+            expect(featureManager.isEnabled("InvalidEnabled")).eventually.eq(false),
+            expect(featureManager.isEnabled("Minimal")).eventually.eq(true),
+            expect(featureManager.isEnabled("NoEnabled")).eventually.eq(false),
+            expect(featureManager.isEnabled("EmptyConditions")).eventually.eq(true)
+        ]);
+    });
+});


### PR DESCRIPTION
According to latest schema, `FeatureFlag.enabled` should be false by default. This PR fixes the evaluation logic and adds test cases.

Schema:
https://github.com/Azure/AppConfiguration/blob/d0ef7d5507b9cee15893eead5861e3b1a82d3efd/docs/FeatureManagement/FeatureFlag.v2.0.0.schema.json#L43-L49