### PR TITLE
Expose IFeatureFilter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@
 
 export { FeatureManager } from "./featureManager";
 export { ConfigurationMapFeatureFlagProvider, ConfigurationObjectFeatureFlagProvider, IFeatureFlagProvider } from "./featureProvider";
+export { IFeatureFilter } from "./filter/FeatureFilter";


### PR DESCRIPTION
## Why this PR?

`IFeatureFilter` should be exported so that users can implement customized feature filter.
