### PR TITLE
Add file extension for import statement

### DIFF
--- a/src/featureManager.ts
+++ b/src/featureManager.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TimeWindowFilter } from "./filter/TimeWindowFilter";
-import { IFeatureFilter } from "./filter/FeatureFilter";
-import { RequirementType } from "./model";
-import { IFeatureFlagProvider } from "./featureProvider";
-import { TargetingFilter } from "./filter/TargetingFilter";
+import { TimeWindowFilter } from "./filter/TimeWindowFilter.js";
+import { IFeatureFilter } from "./filter/FeatureFilter.js";
+import { RequirementType } from "./model.js";
+import { IFeatureFlagProvider } from "./featureProvider.js";
+import { TargetingFilter } from "./filter/TargetingFilter.js";
 
 export class FeatureManager {
     #provider: IFeatureFlagProvider;

--- a/src/featureProvider.ts
+++ b/src/featureProvider.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IGettable } from "./gettable";
-import { FeatureFlag, FeatureManagementConfiguration, FEATURE_MANAGEMENT_KEY, FEATURE_FLAGS_KEY } from "./model";
+import { IGettable } from "./gettable.js";
+import { FeatureFlag, FeatureManagementConfiguration, FEATURE_MANAGEMENT_KEY, FEATURE_FLAGS_KEY } from "./model.js";
 
 export interface IFeatureFlagProvider {
     /**

--- a/src/filter/TargetingFilter.ts
+++ b/src/filter/TargetingFilter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IFeatureFilter } from "./FeatureFilter";
+import { IFeatureFilter } from "./FeatureFilter.js";
 import { createHash } from "crypto";
 
 type TargetingFilterParameters = {

--- a/src/filter/TimeWindowFilter.ts
+++ b/src/filter/TimeWindowFilter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IFeatureFilter } from "./FeatureFilter";
+import { IFeatureFilter } from "./FeatureFilter.js";
 
 // [Start, End)
 type TimeWindowParameters = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { FeatureManager } from "./featureManager";
-export { ConfigurationMapFeatureFlagProvider, ConfigurationObjectFeatureFlagProvider, IFeatureFlagProvider } from "./featureProvider";
+export { FeatureManager } from "./featureManager.js";
+export { ConfigurationMapFeatureFlagProvider, ConfigurationObjectFeatureFlagProvider, IFeatureFlagProvider } from "./featureProvider.js";

--- a/test/exportedApi.ts
+++ b/test/exportedApi.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export * from "../src";
+export * from "../src/index.js";

--- a/test/featureManager.test.ts
+++ b/test/featureManager.test.ts
@@ -6,7 +6,7 @@ import * as chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-import { FeatureManager, ConfigurationObjectFeatureFlagProvider, ConfigurationMapFeatureFlagProvider } from "./exportedApi";
+import { FeatureManager, ConfigurationObjectFeatureFlagProvider, ConfigurationMapFeatureFlagProvider } from "./exportedApi.js";
 
 describe("feature manager", () => {
     it("should load from json string", () => {

--- a/test/noFilters.test.ts
+++ b/test/noFilters.test.ts
@@ -6,7 +6,7 @@ import * as chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-import { FeatureManager, ConfigurationObjectFeatureFlagProvider } from "./exportedApi";
+import { FeatureManager, ConfigurationObjectFeatureFlagProvider } from "./exportedApi.js";
 
 const featureFlagsDataObject = {
     "feature_management": {

--- a/test/targetingFilter.test.ts
+++ b/test/targetingFilter.test.ts
@@ -6,7 +6,7 @@ import * as chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-import { FeatureManager, ConfigurationMapFeatureFlagProvider } from "./exportedApi";
+import { FeatureManager, ConfigurationMapFeatureFlagProvider } from "./exportedApi.js";
 
 const complexTargetingFeature = {
     "id": "ComplexTargeting",


### PR DESCRIPTION
## Why this PR?

1. Follow this PR: https://github.com/Azure/azure-sdk-for-js/pull/26238 to add .js extension to import files
2. Follow this spec: https://nodejs.org/dist/latest/docs/api/esm.html#import-specifiers Notice that 'The file extension is always necessary for these.'