### PR TITLE
Add basic telemetry support

### DIFF
--- a/sdk/feature-management/src/featureManager.ts
+++ b/sdk/feature-management/src/featureManager.ts
@@ -14,6 +14,7 @@ import { isTargetedGroup, isTargetedPercentile, isTargetedUser } from "./common/
 export class FeatureManager implements IFeatureManager {
     #provider: IFeatureFlagProvider;
     #featureFilters: Map<string, IFeatureFilter> = new Map();
+    #onFeatureEvaluated?: (event: EvaluationResult) => void;
 
     constructor(provider: IFeatureFlagProvider, options?: FeatureManagerOptions) {
         this.#provider = provider;
@@ -24,6 +25,8 @@ export class FeatureManager implements IFeatureManager {
         for (const filter of [...builtinFilters, ...(options?.customFilters ?? [])]) {
             this.#featureFilters.set(filter.name, filter);
         }
+
+        this.#onFeatureEvaluated = options?.onFeatureEvaluated;
     }
 
     async listFeatureNames(): Promise<string[]> {
@@ -127,6 +130,9 @@ export class FeatureManager implements IFeatureManager {
         // Evaluate if the feature is enabled.
         result.enabled = await this.#isEnabled(featureFlag, context);
 
+        const targetingContext = context as ITargetingContext;
+        result.userId = targetingContext?.userId;
+
         // Determine Variant
         let variantDef: VariantDefinition | undefined;
         let reason: VariantAssignmentReason = VariantAssignmentReason.None;
@@ -146,7 +152,7 @@ export class FeatureManager implements IFeatureManager {
             } else {
                 // enabled, assign based on allocation
                 if (context !== undefined && featureFlag.allocation !== undefined) {
-                    const variantAndReason = await this.#assignVariant(featureFlag, context as ITargetingContext);
+                    const variantAndReason = await this.#assignVariant(featureFlag, targetingContext);
                     variantDef = variantAndReason.variant;
                     reason = variantAndReason.reason;
                 }
@@ -164,9 +170,6 @@ export class FeatureManager implements IFeatureManager {
             }
         }
 
-        // TODO: send telemetry for variant assignment reason in the future.
-        console.log(`Variant assignment for feature ${featureName}: ${variantDef?.name ?? "default"} (${reason})`);
-
         result.variant = variantDef !== undefined ? new Variant(variantDef.name, variantDef.configuration_value) : undefined;
         result.variantAssignmentReason = reason;
 
@@ -179,12 +182,72 @@ export class FeatureManager implements IFeatureManager {
             }
         }
 
+        if (featureFlag.telemetry?.enabled && this.#onFeatureEvaluated !== undefined) {
+            this.#onFeatureEvaluated(result);
+        }
+
         return result;
     }
 }
 
-interface FeatureManagerOptions {
+export interface FeatureManagerOptions {
+    /**
+     * The custom filters to be used by the feature manager.
+     */
     customFilters?: IFeatureFilter[];
+
+    /**
+     * The callback function that is called when a feature flag is evaluated.
+     * The callback function is called only when telemetry is enabled for the feature flag.
+     */
+    onFeatureEvaluated?: (event: EvaluationResult) => void;
+}
+
+export class EvaluationResult {
+    constructor(
+        // feature flag definition
+        public readonly feature: FeatureFlag | undefined,
+
+        // enabled state
+        public enabled: boolean = false,
+
+        // variant assignment
+        public userId: string | undefined = undefined,
+        public variant: Variant | undefined = undefined,
+        public variantAssignmentReason: VariantAssignmentReason = VariantAssignmentReason.None
+    ) { }
+}
+
+export enum VariantAssignmentReason {
+    /**
+     * Variant allocation did not happen. No variant is assigned.
+     */
+    None = "None",
+
+    /**
+     * The default variant is assigned when a feature flag is disabled.
+     */
+    DefaultWhenDisabled = "DefaultWhenDisabled",
+
+    /**
+     * The default variant is assigned because of no applicable user/group/percentile allocation when a feature flag is enabled.
+     */
+    DefaultWhenEnabled = "DefaultWhenEnabled",
+
+    /**
+     * The variant is assigned because of the user allocation when a feature flag is enabled.
+     */
+    User = "User",
+
+    /**
+     * The variant is assigned because of the group allocation when a feature flag is enabled.
+     */
+    Group = "Group",
+
+    /**
+     * The variant is assigned because of the percentile allocation when a feature flag is enabled.
+     */
+    Percentile = "Percentile"
 }
 
 /**
@@ -225,49 +288,3 @@ type VariantAssignment = {
     variant: VariantDefinition | undefined;
     reason: VariantAssignmentReason;
 };
-
-enum VariantAssignmentReason {
-    /**
-     * Variant allocation did not happen. No variant is assigned.
-     */
-    None,
-
-    /**
-     * The default variant is assigned when a feature flag is disabled.
-     */
-    DefaultWhenDisabled,
-
-    /**
-     * The default variant is assigned because of no applicable user/group/percentile allocation when a feature flag is enabled.
-     */
-    DefaultWhenEnabled,
-
-    /**
-     * The variant is assigned because of the user allocation when a feature flag is enabled.
-     */
-    User,
-
-    /**
-     * The variant is assigned because of the group allocation when a feature flag is enabled.
-     */
-    Group,
-
-    /**
-     * The variant is assigned because of the percentile allocation when a feature flag is enabled.
-     */
-    Percentile
-}
-
-class EvaluationResult {
-    constructor(
-        // feature flag definition
-        public readonly feature: FeatureFlag | undefined,
-
-        // enabled state
-        public enabled: boolean = false,
-
-        // variant assignment
-        public variant: Variant | undefined = undefined,
-        public variantAssignmentReason: VariantAssignmentReason = VariantAssignmentReason.None
-    ) { }
-}

--- a/sdk/feature-management/src/featureManager.ts
+++ b/sdk/feature-management/src/featureManager.ts
@@ -181,7 +181,7 @@ export class FeatureManager implements IFeatureManager {
                 result.enabled = false;
             }
         }
-        
+
         // The callback will only be executed if telemetry is enabled for the feature flag
         if (featureFlag.telemetry?.enabled && this.#onFeatureEvaluated !== undefined) {
             this.#onFeatureEvaluated(result);

--- a/sdk/feature-management/src/featureManager.ts
+++ b/sdk/feature-management/src/featureManager.ts
@@ -181,7 +181,8 @@ export class FeatureManager implements IFeatureManager {
                 result.enabled = false;
             }
         }
-
+        
+        // The callback will only be executed if telemetry is enabled for the feature flag
         if (featureFlag.telemetry?.enabled && this.#onFeatureEvaluated !== undefined) {
             this.#onFeatureEvaluated(result);
         }

--- a/sdk/feature-management/src/index.ts
+++ b/sdk/feature-management/src/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { FeatureManager } from "./featureManager.js";
+export { FeatureManager, FeatureManagerOptions, EvaluationResult, VariantAssignmentReason } from "./featureManager.js";
 export { ConfigurationMapFeatureFlagProvider, ConfigurationObjectFeatureFlagProvider, IFeatureFlagProvider } from "./featureProvider.js";
 export { IFeatureFilter } from "./filter/FeatureFilter.js";

--- a/sdk/feature-management/test/featureEvaluation.test.ts
+++ b/sdk/feature-management/test/featureEvaluation.test.ts
@@ -17,7 +17,7 @@ const setEvaluationResult = (result: EvaluationResult) => {
 };
 
 describe("feature evaluation", () => {
-    beforeEach(function() {
+    beforeEach(() => {
         evaluationResult = undefined;
     });
 

--- a/sdk/feature-management/test/featureEvaluation.test.ts
+++ b/sdk/feature-management/test/featureEvaluation.test.ts
@@ -2,9 +2,8 @@
 // Licensed under the MIT license.
 
 import * as chai from "chai";
-const expect = chai.expect;
-
 import { FeatureManager, ConfigurationObjectFeatureFlagProvider, EvaluationResult, VariantAssignmentReason } from "../";
+const expect = chai.expect;
 
 let called: boolean = false;
 const dummyCallback = () => {

--- a/sdk/feature-management/test/featureEvaluation.test.ts
+++ b/sdk/feature-management/test/featureEvaluation.test.ts
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+const expect = chai.expect;
+
+import { FeatureManager, ConfigurationObjectFeatureFlagProvider, EvaluationResult, VariantAssignmentReason } from "../";
+
+let called: boolean = false;
+const dummyCallback = () => {
+    called = true;
+};
+
+let evaluationResult: EvaluationResult;
+const setEvaluationResult = (result: EvaluationResult) => {
+    evaluationResult = result;
+};
+
+describe("feature evaluation", () => {
+    it("should not call onFeatureEvaluated when telemetry is not enabled", async () => {
+        const jsonObject = {
+            "feature_management": {
+                "feature_flags": [
+                    {
+                        "id": "TestFeature",
+                        "enabled": true,
+                        "telemetry": { "enabled": false }
+                    }
+                ]
+            }
+        };
+
+        const provider = new ConfigurationObjectFeatureFlagProvider(jsonObject);
+        const featureManager = new FeatureManager(provider, { onFeatureEvaluated: dummyCallback});
+
+        await featureManager.isEnabled("TestFeature");
+        expect(called).to.eq(false);
+    });
+
+    it("should not assign variant when there is no variants", async () => {
+        const jsonObject = {
+            "feature_management": {
+                "feature_flags": [
+                    {
+                        "id": "TestFeature",
+                        "enabled": true,
+                        "allocation": { "default_when_enabled": "Big" },
+                        "telemetry": { "enabled": true}
+                    }
+                ]
+            }
+        };
+
+        const provider = new ConfigurationObjectFeatureFlagProvider(jsonObject);
+        const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
+
+        await featureManager.isEnabled("TestFeature");
+        expect(evaluationResult.feature?.id).to.eq("TestFeature");
+        expect(evaluationResult.enabled).to.eq(true);
+        expect(evaluationResult.userId).to.eq(undefined);
+        expect(evaluationResult.variant).to.eq(undefined);
+        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.None);
+
+        evaluationResult = new EvaluationResult(undefined);
+    });
+
+    it("should assign variant for reason DefaultWhenEnabled", async () => {
+        const jsonObject = {
+            "feature_management": {
+                "feature_flags": [
+                    {
+                        "id": "TestFeature1",
+                        "enabled": true,
+                        "variants": [ { "name": "Big", "status_override": "Disabled" }, { "name": "Small" } ],
+                        "allocation": {
+                            "default_when_enabled": "Big",
+                            "user": [ { "variant": "Small", "users": [ "Jeff" ] } ]
+                        },
+                        "telemetry": { "enabled": true}
+                    },
+                    {
+                        "id": "TestFeature2",
+                        "enabled": true,
+                        "variants": [ { "name": "Big" } ],
+                        "telemetry": { "enabled": true}
+                    }
+                ]
+            }
+        };
+
+        const provider = new ConfigurationObjectFeatureFlagProvider(jsonObject);
+        const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
+
+        await featureManager.getVariant("TestFeature1", { userId: "Jim" });
+        expect(evaluationResult.feature?.id).to.eq("TestFeature1");
+        expect(evaluationResult.enabled).to.eq(false); // status override
+        expect(evaluationResult.userId).to.eq("Jim");
+        expect(evaluationResult.variant?.name).to.eq("Big");
+        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenEnabled);
+
+        evaluationResult = new EvaluationResult(undefined);
+
+        await featureManager.getVariant("TestFeature2", { userId: "Jim" });
+        expect(evaluationResult.feature?.id).to.eq("TestFeature2");
+        expect(evaluationResult.enabled).to.eq(true);
+        expect(evaluationResult.userId).to.eq("Jim");
+        expect(evaluationResult.variant).to.eq(undefined);
+        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenEnabled);
+
+        evaluationResult = new EvaluationResult(undefined);
+    });
+
+    it("should assign variant for reason DefaultWhenDisabled", async () => {
+        const jsonObject = {
+            "feature_management": {
+                "feature_flags": [
+                    {
+                        "id": "TestFeature1",
+                        "enabled": false,
+                        "variants": [ { "name": "Small", "status_override": "Enabled" }, { "name": "Big" } ],
+                        "allocation": {
+                            "default_when_disabled": "Small",
+                            "user": [ { "variant": "Big", "users": [ "Jeff" ] } ]
+                        },
+                        "telemetry": { "enabled": true}
+                    },
+                    {
+                        "id": "TestFeature2",
+                        "enabled": false,
+                        "variants": [ { "name": "Small" } ],
+                        "telemetry": { "enabled": true}
+                    }
+                ]
+            }
+        };
+
+        const provider = new ConfigurationObjectFeatureFlagProvider(jsonObject);
+        const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
+
+        await featureManager.getVariant("TestFeature1", { userId: "Jeff" });
+        expect(evaluationResult.feature?.id).to.eq("TestFeature1");
+        expect(evaluationResult.enabled).to.eq(false); // status oveerride won't work when feature's enabled is false
+        expect(evaluationResult.userId).to.eq("Jeff");
+        expect(evaluationResult.variant?.name).to.eq("Small");
+        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenDisabled);
+
+        evaluationResult = new EvaluationResult(undefined);
+
+        await featureManager.getVariant("TestFeature2", { userId: "Jeff" });
+        expect(evaluationResult.feature?.id).to.eq("TestFeature2");
+        expect(evaluationResult.enabled).to.eq(false);
+        expect(evaluationResult.userId).to.eq("Jeff");
+        expect(evaluationResult.variant).to.eq(undefined);
+        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenDisabled);
+
+        evaluationResult = new EvaluationResult(undefined);
+    });
+
+    it("should assign variant for reason User", async () => {
+        const jsonObject = {
+            "feature_management": {
+                "feature_flags": [
+                    {
+                        "id": "TestFeature",
+                        "enabled": true,
+                        "variants": [ { "name": "Big" } ],
+                        "allocation": { "user": [ { "variant": "Big", "users": [ "Jeff" ] } ] },
+                        "telemetry": { "enabled": true}
+                    }
+                ]
+            }
+        };
+
+        const provider = new ConfigurationObjectFeatureFlagProvider(jsonObject);
+        const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
+
+        await featureManager.getVariant("TestFeature", { userId: "Jeff" });
+        expect(evaluationResult.feature?.id).to.eq("TestFeature");
+        expect(evaluationResult.enabled).to.eq(true);
+        expect(evaluationResult.userId).to.eq("Jeff");
+        expect(evaluationResult.variant?.name).to.eq("Big");
+        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.User);
+
+        evaluationResult = new EvaluationResult(undefined);
+    });
+
+    it("should assign variant for reason Group", async () => {
+        const jsonObject = {
+            "feature_management": {
+                "feature_flags": [
+                    {
+                        "id": "TestFeature",
+                        "enabled": true,
+                        "variants": [ { "name": "Big" } ],
+                        "allocation": { "group": [ { "variant": "Big", "groups": [ "admin" ] } ] },
+                        "telemetry": { "enabled": true}
+                    }
+                ]
+            }
+        };
+
+        const provider = new ConfigurationObjectFeatureFlagProvider(jsonObject);
+        const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
+
+        await featureManager.getVariant("TestFeature", { userId: "Jeff", groups: ["admin"] });
+        expect(evaluationResult.feature?.id).to.eq("TestFeature");
+        expect(evaluationResult.enabled).to.eq(true);
+        expect(evaluationResult.userId).to.eq("Jeff");
+        expect(evaluationResult.variant?.name).to.eq("Big");
+        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.Group);
+
+        evaluationResult = new EvaluationResult(undefined);
+    });
+
+    it("should assign variant for reason Percentile", async () => {
+        const jsonObject = {
+            "feature_management": {
+                "feature_flags": [
+                    {
+                        "id": "TestFeature",
+                        "enabled": true,
+                        "variants": [ { "name": "Big", "status_override": "Disabled" } ],
+                        "allocation": { "percentile": [ { "variant": "Big", "from": 0, "to": 50 } ], "seed": "1234" },
+                        "telemetry": { "enabled": true}
+                    }
+                ]
+            }
+        };
+
+        const provider = new ConfigurationObjectFeatureFlagProvider(jsonObject);
+        const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
+
+        await featureManager.getVariant("TestFeature", { userId: "Marsha" });
+        expect(evaluationResult.feature?.id).to.eq("TestFeature");
+        expect(evaluationResult.enabled).to.eq(false); // status override
+        expect(evaluationResult.userId).to.eq("Marsha");
+        expect(evaluationResult.variant?.name).to.eq("Big");
+        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.Percentile);
+
+        evaluationResult = new EvaluationResult(undefined);
+    });
+});

--- a/sdk/feature-management/test/featureEvaluation.test.ts
+++ b/sdk/feature-management/test/featureEvaluation.test.ts
@@ -11,12 +11,16 @@ const dummyCallback = () => {
     called = true;
 };
 
-let evaluationResult: EvaluationResult;
+let evaluationResult: EvaluationResult | undefined;
 const setEvaluationResult = (result: EvaluationResult) => {
     evaluationResult = result;
 };
 
 describe("feature evaluation", () => {
+    beforeEach(function() {
+        evaluationResult = undefined;
+    });
+
     it("should not call onFeatureEvaluated when telemetry is not enabled", async () => {
         const jsonObject = {
             "feature_management": {
@@ -55,13 +59,11 @@ describe("feature evaluation", () => {
         const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
 
         await featureManager.isEnabled("TestFeature");
-        expect(evaluationResult.feature?.id).to.eq("TestFeature");
-        expect(evaluationResult.enabled).to.eq(true);
-        expect(evaluationResult.userId).to.eq(undefined);
-        expect(evaluationResult.variant).to.eq(undefined);
-        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.None);
-
-        evaluationResult = new EvaluationResult(undefined);
+        expect(evaluationResult?.feature?.id).to.eq("TestFeature");
+        expect(evaluationResult?.enabled).to.eq(true);
+        expect(evaluationResult?.userId).to.eq(undefined);
+        expect(evaluationResult?.variant).to.eq(undefined);
+        expect(evaluationResult?.variantAssignmentReason).to.eq(VariantAssignmentReason.None);
     });
 
     it("should assign variant for reason DefaultWhenEnabled", async () => {
@@ -92,22 +94,18 @@ describe("feature evaluation", () => {
         const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
 
         await featureManager.getVariant("TestFeature1", { userId: "Jim" });
-        expect(evaluationResult.feature?.id).to.eq("TestFeature1");
-        expect(evaluationResult.enabled).to.eq(false); // status override
-        expect(evaluationResult.userId).to.eq("Jim");
-        expect(evaluationResult.variant?.name).to.eq("Big");
-        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenEnabled);
-
-        evaluationResult = new EvaluationResult(undefined);
+        expect(evaluationResult?.feature?.id).to.eq("TestFeature1");
+        expect(evaluationResult?.enabled).to.eq(false); // status override
+        expect(evaluationResult?.userId).to.eq("Jim");
+        expect(evaluationResult?.variant?.name).to.eq("Big");
+        expect(evaluationResult?.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenEnabled);
 
         await featureManager.getVariant("TestFeature2", { userId: "Jim" });
-        expect(evaluationResult.feature?.id).to.eq("TestFeature2");
-        expect(evaluationResult.enabled).to.eq(true);
-        expect(evaluationResult.userId).to.eq("Jim");
-        expect(evaluationResult.variant).to.eq(undefined);
-        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenEnabled);
-
-        evaluationResult = new EvaluationResult(undefined);
+        expect(evaluationResult?.feature?.id).to.eq("TestFeature2");
+        expect(evaluationResult?.enabled).to.eq(true);
+        expect(evaluationResult?.userId).to.eq("Jim");
+        expect(evaluationResult?.variant).to.eq(undefined);
+        expect(evaluationResult?.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenEnabled);
     });
 
     it("should assign variant for reason DefaultWhenDisabled", async () => {
@@ -138,22 +136,18 @@ describe("feature evaluation", () => {
         const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
 
         await featureManager.getVariant("TestFeature1", { userId: "Jeff" });
-        expect(evaluationResult.feature?.id).to.eq("TestFeature1");
-        expect(evaluationResult.enabled).to.eq(false); // status oveerride won't work when feature's enabled is false
-        expect(evaluationResult.userId).to.eq("Jeff");
-        expect(evaluationResult.variant?.name).to.eq("Small");
-        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenDisabled);
-
-        evaluationResult = new EvaluationResult(undefined);
+        expect(evaluationResult?.feature?.id).to.eq("TestFeature1");
+        expect(evaluationResult?.enabled).to.eq(false); // status oveerride won't work when feature's enabled is false
+        expect(evaluationResult?.userId).to.eq("Jeff");
+        expect(evaluationResult?.variant?.name).to.eq("Small");
+        expect(evaluationResult?.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenDisabled);
 
         await featureManager.getVariant("TestFeature2", { userId: "Jeff" });
-        expect(evaluationResult.feature?.id).to.eq("TestFeature2");
-        expect(evaluationResult.enabled).to.eq(false);
-        expect(evaluationResult.userId).to.eq("Jeff");
-        expect(evaluationResult.variant).to.eq(undefined);
-        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenDisabled);
-
-        evaluationResult = new EvaluationResult(undefined);
+        expect(evaluationResult?.feature?.id).to.eq("TestFeature2");
+        expect(evaluationResult?.enabled).to.eq(false);
+        expect(evaluationResult?.userId).to.eq("Jeff");
+        expect(evaluationResult?.variant).to.eq(undefined);
+        expect(evaluationResult?.variantAssignmentReason).to.eq(VariantAssignmentReason.DefaultWhenDisabled);
     });
 
     it("should assign variant for reason User", async () => {
@@ -175,13 +169,11 @@ describe("feature evaluation", () => {
         const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
 
         await featureManager.getVariant("TestFeature", { userId: "Jeff" });
-        expect(evaluationResult.feature?.id).to.eq("TestFeature");
-        expect(evaluationResult.enabled).to.eq(true);
-        expect(evaluationResult.userId).to.eq("Jeff");
-        expect(evaluationResult.variant?.name).to.eq("Big");
-        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.User);
-
-        evaluationResult = new EvaluationResult(undefined);
+        expect(evaluationResult?.feature?.id).to.eq("TestFeature");
+        expect(evaluationResult?.enabled).to.eq(true);
+        expect(evaluationResult?.userId).to.eq("Jeff");
+        expect(evaluationResult?.variant?.name).to.eq("Big");
+        expect(evaluationResult?.variantAssignmentReason).to.eq(VariantAssignmentReason.User);
     });
 
     it("should assign variant for reason Group", async () => {
@@ -203,13 +195,11 @@ describe("feature evaluation", () => {
         const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
 
         await featureManager.getVariant("TestFeature", { userId: "Jeff", groups: ["admin"] });
-        expect(evaluationResult.feature?.id).to.eq("TestFeature");
-        expect(evaluationResult.enabled).to.eq(true);
-        expect(evaluationResult.userId).to.eq("Jeff");
-        expect(evaluationResult.variant?.name).to.eq("Big");
-        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.Group);
-
-        evaluationResult = new EvaluationResult(undefined);
+        expect(evaluationResult?.feature?.id).to.eq("TestFeature");
+        expect(evaluationResult?.enabled).to.eq(true);
+        expect(evaluationResult?.userId).to.eq("Jeff");
+        expect(evaluationResult?.variant?.name).to.eq("Big");
+        expect(evaluationResult?.variantAssignmentReason).to.eq(VariantAssignmentReason.Group);
     });
 
     it("should assign variant for reason Percentile", async () => {
@@ -231,12 +221,10 @@ describe("feature evaluation", () => {
         const featureManager = new FeatureManager(provider, { onFeatureEvaluated: setEvaluationResult});
 
         await featureManager.getVariant("TestFeature", { userId: "Marsha" });
-        expect(evaluationResult.feature?.id).to.eq("TestFeature");
-        expect(evaluationResult.enabled).to.eq(false); // status override
-        expect(evaluationResult.userId).to.eq("Marsha");
-        expect(evaluationResult.variant?.name).to.eq("Big");
-        expect(evaluationResult.variantAssignmentReason).to.eq(VariantAssignmentReason.Percentile);
-
-        evaluationResult = new EvaluationResult(undefined);
+        expect(evaluationResult?.feature?.id).to.eq("TestFeature");
+        expect(evaluationResult?.enabled).to.eq(false); // status override
+        expect(evaluationResult?.userId).to.eq("Marsha");
+        expect(evaluationResult?.variant?.name).to.eq("Big");
+        expect(evaluationResult?.variantAssignmentReason).to.eq(VariantAssignmentReason.Percentile);
     });
 });

--- a/sdk/feature-management/test/featureManager.test.ts
+++ b/sdk/feature-management/test/featureManager.test.ts
@@ -3,10 +3,9 @@
 
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
+import { FeatureManager, ConfigurationObjectFeatureFlagProvider, ConfigurationMapFeatureFlagProvider } from "../";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
-
-import { FeatureManager, ConfigurationObjectFeatureFlagProvider, ConfigurationMapFeatureFlagProvider } from "../";
 
 describe("feature manager", () => {
     it("should load from json string", () => {

--- a/sdk/feature-management/test/noFilters.test.ts
+++ b/sdk/feature-management/test/noFilters.test.ts
@@ -3,10 +3,9 @@
 
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
+import { FeatureManager, ConfigurationObjectFeatureFlagProvider } from "../";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
-
-import { FeatureManager, ConfigurationObjectFeatureFlagProvider } from "../";
 
 const featureFlagsDataObject = {
     "feature_management": {

--- a/sdk/feature-management/test/targetingFilter.test.ts
+++ b/sdk/feature-management/test/targetingFilter.test.ts
@@ -3,10 +3,9 @@
 
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
+import { FeatureManager, ConfigurationMapFeatureFlagProvider } from "../";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
-
-import { FeatureManager, ConfigurationMapFeatureFlagProvider } from "../";
 
 const complexTargetingFeature = {
     "id": "ComplexTargeting",

--- a/sdk/feature-management/test/variant.test.ts
+++ b/sdk/feature-management/test/variant.test.ts
@@ -3,11 +3,10 @@
 
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-const expect = chai.expect;
-
 import { FeatureManager, ConfigurationObjectFeatureFlagProvider } from "../";
 import { Features, featureFlagsConfigurationObject } from "./sampleFeatureFlags.js";
+chai.use(chaiAsPromised);
+const expect = chai.expect;
 
 describe("feature variant", () => {
 


### PR DESCRIPTION
## Why this PR?

Allow user to set onFeatureEvaluated callback which be executed whenever a feature flag with telemetry enabled is evaluated.