### PR TITLE
Stablize v2

### DIFF
--- a/sdk/feature-management-applicationinsights-browser/package.json
+++ b/sdk/feature-management-applicationinsights-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/feature-management-applicationinsights-browser",
-  "version": "2.0.0-preview.3",
+  "version": "2.0.0",
   "description": "Feature Management Application Insights Plugin for Browser provides a solution for sending feature flag evaluation events produced by the Feature Management library.",
   "main": "./dist/umd/index.js",
   "module": "./dist/esm/index.js",
@@ -24,6 +24,9 @@
     "url": "git+https://github.com/microsoft/FeatureManagement-JavaScript.git"
   },
   "license": "MIT",
+  "publishConfig": {
+    "tag": "stable"
+  },
   "bugs": {
     "url": "https://github.com/microsoft/FeatureManagement-JavaScript/issues"
   },
@@ -42,7 +45,7 @@
   },
   "dependencies": {
     "@microsoft/applicationinsights-web": "^3.3.2",
-    "@microsoft/feature-management": "2.0.0-preview.3"
+    "@microsoft/feature-management": "2.0.0"
   }
 }
   

--- a/sdk/feature-management-applicationinsights-browser/src/version.ts
+++ b/sdk/feature-management-applicationinsights-browser/src/version.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const VERSION = "2.0.0-preview.3";
+export const VERSION = "2.0.0";

--- a/sdk/feature-management-applicationinsights-node/package.json
+++ b/sdk/feature-management-applicationinsights-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/feature-management-applicationinsights-node",
-  "version": "2.0.0-preview.3",
+  "version": "2.0.0",
   "description": "Feature Management Application Insights Plugin for Node.js provides a solution for sending feature flag evaluation events produced by the Feature Management library.",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
@@ -24,6 +24,9 @@
     "url": "git+https://github.com/microsoft/FeatureManagement-JavaScript.git"
   },
   "license": "MIT",
+  "publishConfig": {
+    "tag": "stable"
+  },
   "bugs": {
     "url": "https://github.com/microsoft/FeatureManagement-JavaScript/issues"
   },
@@ -42,7 +45,7 @@
   },
   "dependencies": {
     "applicationinsights": "^2.9.6",
-    "@microsoft/feature-management": "2.0.0-preview.3"
+    "@microsoft/feature-management": "2.0.0"
   }
 }
   

--- a/sdk/feature-management-applicationinsights-node/src/version.ts
+++ b/sdk/feature-management-applicationinsights-node/src/version.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const VERSION = "2.0.0-preview.3";
+export const VERSION = "2.0.0";

--- a/sdk/feature-management/package-lock.json
+++ b/sdk/feature-management/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/feature-management",
-  "version": "2.0.0-preview.3",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/sdk/feature-management/package.json
+++ b/sdk/feature-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/feature-management",
-  "version": "2.0.0-preview.3",
+  "version": "2.0.0",
   "description": "Feature Management is a library for enabling/disabling features at runtime. Developers can use feature flags in simple use cases like conditional statement to more advanced scenarios like conditionally adding routes.",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
@@ -26,6 +26,9 @@
     "url": "git+https://github.com/microsoft/FeatureManagement-JavaScript.git"
   },
   "license": "MIT",
+  "publishConfig": {
+    "tag": "stable"
+  },
   "bugs": {
     "url": "https://github.com/microsoft/FeatureManagement-JavaScript/issues"
   },

--- a/sdk/feature-management/src/telemetry/featureEvaluationEvent.ts
+++ b/sdk/feature-management/src/telemetry/featureEvaluationEvent.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { EvaluationResult, VariantAssignmentReason } from "../featureManager";
+import { EvaluationResult } from "../featureManager";
 import { EVALUATION_EVENT_VERSION } from "../version.js";
 
 const VERSION = "Version";
@@ -10,8 +10,6 @@ const ENABLED = "Enabled";
 const TARGETING_ID = "TargetingId";
 const VARIANT = "Variant";
 const VARIANT_ASSIGNMENT_REASON = "VariantAssignmentReason";
-const DEFAULT_WHEN_ENABLED = "DefaultWhenEnabled";
-const VARIANT_ASSIGNMENT_PERCENTAGE = "VariantAssignmentPercentage";
 
 export function createFeatureEvaluationEventProperties(result: EvaluationResult): any {
     if (result.feature === undefined) {
@@ -27,31 +25,6 @@ export function createFeatureEvaluationEventProperties(result: EvaluationResult)
         [VARIANT]: result.variant ? result.variant.name : "",
         [VARIANT_ASSIGNMENT_REASON]: result.variantAssignmentReason,
     };
-
-    if (result.feature.allocation?.default_when_enabled) {
-        eventProperties[DEFAULT_WHEN_ENABLED] = result.feature.allocation.default_when_enabled;
-    }
-
-    if (result.variantAssignmentReason === VariantAssignmentReason.DefaultWhenEnabled) {
-        let percentileAllocationPercentage = 0;
-        if (result.variant !== undefined && result.feature.allocation !== undefined && result.feature.allocation.percentile !== undefined) {
-            for (const percentile of result.feature.allocation.percentile) {
-                percentileAllocationPercentage += percentile.to - percentile.from;
-            }
-        }
-        eventProperties[VARIANT_ASSIGNMENT_PERCENTAGE] = (100 - percentileAllocationPercentage).toString();
-    }
-    else if (result.variantAssignmentReason === VariantAssignmentReason.Percentile) {
-        let percentileAllocationPercentage = 0;
-        if (result.variant !== undefined && result.feature.allocation !== undefined && result.feature.allocation.percentile !== undefined) {
-            for (const percentile of result.feature.allocation.percentile) {
-                if (percentile.variant === result.variant.name) {
-                    percentileAllocationPercentage += percentile.to - percentile.from;
-                }
-            }
-        }
-        eventProperties[VARIANT_ASSIGNMENT_PERCENTAGE] = percentileAllocationPercentage.toString();
-    }
 
     const metadata = result.feature.telemetry?.metadata;
     if (metadata) {

--- a/sdk/feature-management/src/version.ts
+++ b/sdk/feature-management/src/version.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const VERSION = "2.0.0-preview.3";
+export const VERSION = "2.0.0";
 export const EVALUATION_EVENT_VERSION = "1.0.0";


### PR DESCRIPTION
Exclude EXP telemetry field from stable release to avoid potential breaking change.

Note: EXP telemetry field has been released in the current preview release.