### PR TITLE
Update build script & Correct browser package

### DIFF
--- a/scripts/build-and-pack.sh
+++ b/scripts/build-and-pack.sh
@@ -5,10 +5,16 @@ set -e
 
 SCRIPT_DIR=$(dirname $(readlink -f $0))
 PROJECT_BASE_DIR=$(dirname $SCRIPT_DIR)
+NPMRC_FILE="$PROJECT_BASE_DIR/.npmrc"
 SDK_DIR="$PROJECT_BASE_DIR/sdk"
 
 PACKAGE="feature-management"
 PACKAGE_DIR="$SDK_DIR/$PACKAGE"
+
+if [ -f "$NPMRC_FILE" ]; then
+    echo "Copy .npmrc file to $PACKAGE_DIR"
+    cp "$NPMRC_FILE" "$PACKAGE_DIR"
+fi
 
 echo "Building package $PACKAGE in $PACKAGE_DIR"
 cd "$PACKAGE_DIR"
@@ -31,6 +37,11 @@ cp "$PACKAGE_DIR"/*.tgz "$PROJECT_BASE_DIR"
 PACKAGE="feature-management-applicationinsights-browser"
 PACKAGE_DIR="$SDK_DIR/$PACKAGE"
 
+if [ -f "$NPMRC_FILE" ]; then
+    echo "Copy .npmrc file to $PACKAGE_DIR"
+    cp "$NPMRC_FILE" "$PACKAGE_DIR"
+fi
+
 echo "Building package $PACKAGE in $PACKAGE_DIR"
 cd "$PACKAGE_DIR"
 
@@ -45,6 +56,11 @@ cp "$PACKAGE_DIR"/*.tgz "$PROJECT_BASE_DIR"
 
 PACKAGE="feature-management-applicationinsights-node"
 PACKAGE_DIR="$SDK_DIR/$PACKAGE"
+
+if [ -f "$NPMRC_FILE" ]; then
+    echo "Copy .npmrc file to $PACKAGE_DIR"
+    cp "$NPMRC_FILE" "$PACKAGE_DIR"
+fi
 
 echo "Building package $PACKAGE in $PACKAGE_DIR"
 cd "$PACKAGE_DIR"

--- a/sdk/feature-management-applicationinsights-browser/package.json
+++ b/sdk/feature-management-applicationinsights-browser/package.json
@@ -2,8 +2,9 @@
   "name": "@microsoft/feature-management-applicationinsights-browser",
   "version": "2.0.0",
   "description": "Feature Management Application Insights Plugin for Browser provides a solution for sending feature flag evaluation events produced by the Feature Management library.",
-  "main": "./dist/umd/index.js",
+  "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",
+  "type": "module",
   "types": "types/index.d.ts",
   "files": [
     "dist/",

--- a/sdk/feature-management-applicationinsights-browser/rollup.config.mjs
+++ b/sdk/feature-management-applicationinsights-browser/rollup.config.mjs
@@ -38,5 +38,5 @@ export default [
     input: "src/index.ts",
     output: [{ file: "types/index.d.ts", format: "esm" }],
     plugins: [dts()],
-  },
+  }
 ];

--- a/sdk/feature-management-applicationinsights-node/rollup.config.mjs
+++ b/sdk/feature-management-applicationinsights-node/rollup.config.mjs
@@ -44,5 +44,5 @@ export default [
     input: "src/index.ts",
     output: [{ file: "types/index.d.ts", format: "esm" }],
     plugins: [dts()],
-  },
+  }
 ];


### PR DESCRIPTION
This PR does two things:

1. Fix the failure of building packages from FeatureManagement-JavaScript repo in our OOB release pipeline.

I fail to build packages from FeatureManagement-JavaScript repo in our OOB release pipeline. It cannot execute `npm install` in any subfolders.(There are three packages in the JS FM repo) The log reported connection error: fail to get npm registry. 

I rerun the some previous successful attempts, they fail now. After debugging, I found that if we placed the Azure`.npmrc` in the subfolder, then `npm install` and `npm link` can be executed as expected (no connection error any more). The possible reason could be the upgrade of agent major version. Previously, it may allow to fall back the default npm registry. but now it only allows Azure Artifact registry.

Our OOB release pipeline will use Azure Artifact registry by creating a `.npmrc` file in the root folder. So I update the build script to copy it to each subfolders.

2. Correct the entry point of the browser package. It is an oversight from #84